### PR TITLE
Optimize module script

### DIFF
--- a/modules/location/layout/layout.gd
+++ b/modules/location/layout/layout.gd
@@ -22,7 +22,7 @@ func layout(card: Card, instant: bool = false) -> bool:
 	if not card.visible:
 		return false
 	
-	if card.is_hovering or _should_layouts.get(card.get_rid()) == false:
+	if card.is_hovering or _should_layouts.get(card.get_rid(), true) == false:
 		_layout_tweens[card.get_rid()].kill()
 		return false
 	
@@ -155,7 +155,8 @@ func card_play_before_hook(card: Card, board_index: int, position: Vector3i) -> 
 
 
 func card_tween_start_hook(card: Card, duration: float, new_position: Vector3, new_rotation: Vector3, new_scale: Vector3) -> bool:
-	_should_layouts[card.get_rid()] = false
+	# This code breaks cards on the board. What does it do?
+	#_should_layouts[card.get_rid()] = false
 	return true
 
 

--- a/scenes/card.gd
+++ b/scenes/card.gd
@@ -323,7 +323,7 @@ func trigger_ability(ability: StringName, send_packet: bool = true) -> bool:
 	if not abilities.has(ability):
 		return false
 	
-	if not await Modules.request(Modules.Hook.CARD_ABILITY_TRIGGER, false, [self, ability, send_packet]):
+	if not await Modules.request(Modules.Hook.CARD_ABILITY_TRIGGER, [self, ability, send_packet]):
 		return false
 	
 	# Wait 1 frame so that `await wait_for_ability` can get called before the ability gets triggered.
@@ -339,7 +339,7 @@ func add_ability(ability: StringName, callback: Callable) -> void:
 	if not abilities.has(ability):
 		abilities[ability] = []
 	
-	if not await Modules.request(Modules.Hook.CARD_ABILITY_ADD, false, [self, ability]):
+	if not await Modules.request(Modules.Hook.CARD_ABILITY_ADD, [self, ability]):
 		return
 	
 	abilities[ability].append(callback)
@@ -351,7 +351,7 @@ func attack_target(target: Variant, send_packet: bool = true) -> bool:
 		Game.feedback("That target is not valid.", Game.FeedbackType.ERROR)
 		return false
 	
-	if not await Modules.request(Modules.Hook.ATTACK, false, [self, target, send_packet]):
+	if not await Modules.request(Modules.Hook.ATTACK, [self, target, send_packet]):
 		return false
 	
 	if target is Card:
@@ -390,7 +390,7 @@ func tween_to(duration: float, new_position: Vector3, new_rotation: Vector3 = ro
 		scale = new_scale
 		return
 	
-	Modules.request(Modules.Hook.CARD_TWEEN_START, true, [self, duration, new_position, new_rotation, new_scale])
+	Modules.request(Modules.Hook.CARD_TWEEN_START, [self, duration, new_position, new_rotation, new_scale])
 	
 	var tween: Tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BOUNCE).set_parallel()
 	tween.tween_property(self, "position", new_position, duration)
@@ -544,7 +544,7 @@ func _update() -> void:
 		armor_label.text = str(player.armor)
 		health_label.text = str(player.health)
 	
-	Modules.request(Modules.Hook.CARD_UPDATE, true, [self])
+	Modules.request(Modules.Hook.CARD_UPDATE, [self])
 	
 	# TODO: Should this be done here?
 	if health <= 0 and location == &"Board" and not is_dying and should_die:
@@ -578,7 +578,7 @@ func _update() -> void:
 		scale = old_scale
 		
 		Game.card_killed.emit(true, self, player, multiplayer.get_unique_id())
-		await Modules.request(Modules.Hook.CARD_KILL, false, [self])
+		await Modules.request(Modules.Hook.CARD_KILL, [self])
 		return
 
 
@@ -599,7 +599,7 @@ func _start_hover() -> void:
 	
 	is_hovering = true
 	
-	Modules.request(Modules.Hook.CARD_HOVER_START, true, [self])
+	Modules.request(Modules.Hook.CARD_HOVER_START, [self])
 	
 	# Animate
 	var player_weight: int = 1 if player == Game.player else -1
@@ -630,7 +630,7 @@ func _stop_hover() -> void:
 		_hover_tween.kill()
 	
 	is_hovering = false
-	Modules.request(Modules.Hook.CARD_HOVER_STOP, true, [self])
+	Modules.request(Modules.Hook.CARD_HOVER_STOP, [self])
 
 
 func _start_dragging() -> void:
@@ -723,7 +723,7 @@ func _start_attacking() -> void:
 		Game.feedback("This card has already attacked this turn.", Game.FeedbackType.ERROR)
 		return
 	
-	if not await Modules.request(Modules.Hook.START_ATTACKING, false, [self]):
+	if not await Modules.request(Modules.Hook.START_ATTACKING, [self]):
 		return
 	
 	var target: Variant = await Target.prompt(position, self, Target.CAN_SELECT_CARDS | Target.CAN_SELECT_HEROES | Target.CAN_SELECT_ENEMY_TARGETS)
@@ -749,7 +749,7 @@ func _make_way_for(card: Card) -> void:
 	if not visible:
 		return
 	
-	Modules.request(Modules.Hook.CARD_MAKE_WAY_START, true, [self, card])
+	Modules.request(Modules.Hook.CARD_MAKE_WAY_START, [self, card])
 	
 	var bias: int = 1 if global_position.x > card.global_position.x else -1
 	var new_position_x: float = _old_position.x + 2 * bias
@@ -764,7 +764,7 @@ func _make_way_for(card: Card) -> void:
 
 
 func _stop_making_way() -> void:
-	Modules.request(Modules.Hook.CARD_MAKE_WAY_STOP, true, [self])
+	Modules.request(Modules.Hook.CARD_MAKE_WAY_STOP, [self])
 
 
 func _refund() -> void:

--- a/scenes/target.gd
+++ b/scenes/target.gd
@@ -82,7 +82,7 @@ func _input_event(camera: Camera3D, event: InputEvent, pos: Vector3, normal: Vec
 				target_selected.emit(null)
 				return _remove()
 			
-			if not await Modules.request(Modules.Hook.SELECT_TARGET, false, [self, flags, collider]):
+			if not await Modules.request(Modules.Hook.SELECT_TARGET, [self, flags, collider]):
 				return
 			
 			player_selected.emit(player)
@@ -93,7 +93,7 @@ func _input_event(camera: Camera3D, event: InputEvent, pos: Vector3, normal: Vec
 				target_selected.emit(null)
 				return _remove()
 			
-			if not await Modules.request(Modules.Hook.SELECT_TARGET, false, [self, flags, collider]):
+			if not await Modules.request(Modules.Hook.SELECT_TARGET, [self, flags, collider]):
 				return
 			
 			card_selected.emit(collider)

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -273,7 +273,7 @@ func end_turn() -> bool:
 		feedback("It is not your turn.", FeedbackType.ERROR)
 		return false
 	
-	if not await Modules.request(Modules.Hook.END_TURN, false, [current_player]):
+	if not await Modules.request(Modules.Hook.END_TURN, [current_player]):
 		return false
 	
 	Packet.send(&"End Turn", current_player.id, [], true)

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -341,10 +341,12 @@ func get_or_null(array: Array, index: int) -> Variant:
 
 #region Private Functions
 func _attack_attacker_is_player_and_target_is_player(attacker: Player, target: Player) -> void:
+	# TODO: Implement.
 	pass
 
 
 func _attack_attacker_is_player_and_target_is_card(attacker: Player, target: Card) -> void:
+	# TODO: Implement.
 	pass
 
 

--- a/scripts/multiplayer/anticheat.gd
+++ b/scripts/multiplayer/anticheat.gd
@@ -50,7 +50,6 @@ func run(packet_type: StringName, sender_peer_id: int, actor_player: Player, inf
 	# Passed the core anticheat. Let the modules do their anticheat.
 	var modules_anticheat_response: bool = await Modules.request(
 		Modules.Hook.ANTICHEAT,
-		false,
 		[packet_type, sender_peer_id, sender_player, actor_player, info],
 	)
 	

--- a/scripts/multiplayer/multiplayer.gd
+++ b/scripts/multiplayer/multiplayer.gd
@@ -283,7 +283,7 @@ func create_blueprint_from_id(id: int, player_id: int, location: StringName, ind
 	var blueprint: Blueprint = Blueprint.create_from_id(id, player)
 	blueprint.card.add_to_location(location, index)
 	
-	await Modules.request(Modules.Hook.BLUEPRINT_CREATE, false, [blueprint])
+	await Modules.request(Modules.Hook.BLUEPRINT_CREATE, [blueprint])
 	
 	return blueprint
 

--- a/scripts/multiplayer/packet.gd
+++ b/scripts/multiplayer/packet.gd
@@ -164,7 +164,7 @@ func _accept(packet_type: StringName, sender_peer_id: int, player_id: int, info:
 		var method: Callable = self[method_name]
 		method.bindv(info).call(player, sender_peer_id)
 	
-	Modules.request(Modules.Hook.ACCEPT_PACKET, false, [packet_type, player, sender_peer_id, info])
+	Modules.request(Modules.Hook.ACCEPT_PACKET, [packet_type, player, sender_peer_id, info])
 
 
 # Here are the functions that gets called on the clients + server when a packet gets sent. Handled in _accept_packet
@@ -309,7 +309,7 @@ func _accept_play_packet(
 	
 	card.override_is_hidden = Game.NullableBool.FALSE
 	
-	if not await Modules.request(Modules.Hook.CARD_PLAY_BEFORE, false, [card, board_index, position]):
+	if not await Modules.request(Modules.Hook.CARD_PLAY_BEFORE, [card, board_index, position]):
 		return
 	
 	await card.tween_to(0.3, position, Vector3.ZERO, Vector3.ONE)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -107,7 +107,7 @@ func play_card(card: Card, board_index: int, send_packet: bool = true) -> bool:
 		Game.feedback("You don't have enough mana.", Game.FeedbackType.ERROR)
 		return false
 	
-	if not await Modules.request(Modules.Hook.CARD_PLAY_CHECK, false, [self, card, board_index, send_packet]):
+	if not await Modules.request(Modules.Hook.CARD_PLAY_CHECK, [self, card, board_index, send_packet]):
 		return false
 	
 	if card.location == &"Hero Power":
@@ -127,7 +127,7 @@ func summon_card(card: Card, board_index: int, send_packet: bool = true) -> bool
 	if board.size() >= Settings.server.max_board_space:
 		return false
 	
-	if not await Modules.request(Modules.Hook.CARD_SUMMON, false, [self, card, board_index, send_packet]):
+	if not await Modules.request(Modules.Hook.CARD_SUMMON, [self, card, board_index, send_packet]):
 		return false
 		
 	Packet.send_if(send_packet, &"Summon", id, [card.location, card.index, board_index], true)
@@ -139,7 +139,7 @@ func add_to_hand(card: Card, hand_index: int, send_packet: bool = true) -> bool:
 	if hand.size() >= Settings.server.max_hand_size:
 		return false
 	
-	if not await Modules.request(Modules.Hook.CARD_ADD_TO_HAND, false, [self, card, hand_index, send_packet]):
+	if not await Modules.request(Modules.Hook.CARD_ADD_TO_HAND, [self, card, hand_index, send_packet]):
 		return false
 	
 	Packet.send_if(send_packet, &"Create Card", id, [
@@ -152,7 +152,7 @@ func add_to_hand(card: Card, hand_index: int, send_packet: bool = true) -> bool:
 
 ## Sends a packet to add a card to the player's deck. Returns if a packet was sent / success.
 func add_to_deck(card: Card, deck_index: int, send_packet: bool = true) -> bool:
-	if not await Modules.request(Modules.Hook.CARD_ADD_TO_DECK, false, [self, card, deck_index, send_packet]):
+	if not await Modules.request(Modules.Hook.CARD_ADD_TO_DECK, [self, card, deck_index, send_packet]):
 		return false
 	
 	Packet.send_if(send_packet, &"Create Card", id, [
@@ -165,7 +165,7 @@ func add_to_deck(card: Card, deck_index: int, send_packet: bool = true) -> bool:
 
 ## Sends a packet for the player to draw a card. Returns if a packet was sent / success.
 func draw_cards(amount: int, send_packet: bool = true) -> bool:
-	if not await Modules.request(Modules.Hook.DRAW_CARDS, false, [self, amount, send_packet]):
+	if not await Modules.request(Modules.Hook.DRAW_CARDS, [self, amount, send_packet]):
 		return false
 	
 	Packet.send_if(send_packet, &"Draw Cards", id, [amount], true)
@@ -174,7 +174,7 @@ func draw_cards(amount: int, send_packet: bool = true) -> bool:
 
 ## Deals [param amount] damage to this player. Does not send a packet.
 func damage(amount: int) -> bool:
-	if not await Modules.request(Modules.Hook.DAMAGE, false, [self, amount, absi(armor - amount)]):
+	if not await Modules.request(Modules.Hook.DAMAGE, [self, amount, absi(armor - amount)]):
 		return false
 	
 	# Armor logic
@@ -219,7 +219,7 @@ static func get_from_peer_id(peer_id: int) -> Player:
 
 #region Private Functions
 func _die() -> void:
-	if not await Modules.request(Modules.Hook.PLAYER_DIE, false, [self]):
+	if not await Modules.request(Modules.Hook.PLAYER_DIE, [self]):
 		return
 	
 	if health > 0 or not should_die:


### PR DESCRIPTION
Closes #9 

Call all hook handlers in a for-loop instead of using a thousand awaits.

- [ ] Look into if it's more performant to somehow only call the hook handlers if it's a hook it cares about. This might save a few falsy if conditions.
- [ ] ~Look into if it's worth it to rewrite this performance critical part of the game in C++~
- [ ] ~Look into if it's worth removing the ability to disable modules.~

~I can't currently test this pr since the game somehow crashes when launching on my laptop, with no logs, so this won't be merged until i can get back to my desktop.~